### PR TITLE
Major overhaul of the clientside card handling + minor improvements:

### DIFF
--- a/carte/games/base.py
+++ b/carte/games/base.py
@@ -261,6 +261,9 @@ class BaseGame(Generic[T_Player]):
             tg.create_task(self._send(player, "draw_card", player_id, card))
             tg.create_task(self._send_others(player, "draw_card", player_id))
 
+    def _next_player(self) -> None:
+        self._current_player_id = (self._current_player_id + 1) % self.number_of_players
+
     async def handle_raw_cmd(
         self, ws: web.WebSocketResponse, player: T_Player | None, msg: aiohttp.WSMessage
     ) -> None:

--- a/carte/games/briscola.py
+++ b/carte/games/briscola.py
@@ -30,8 +30,6 @@ class Briscola(BaseGame[Player], version=1, number_of_players=2, hand_size=3):
         self._played_cards: dict[Player, Card] = {}
 
     def _board_state(self, ws_player: Player | None) -> Iterator[list[Any]]:
-        if not self._briscola_drawn:
-            yield ["show_briscola", self._briscola]
 
         for player_id, player in enumerate(self._players):
             for card in player.hand:
@@ -40,9 +38,15 @@ class Briscola(BaseGame[Player], version=1, number_of_players=2, hand_size=3):
                 else:
                     yield ["draw_card", player_id]
 
+        if not self._briscola_drawn:
+            yield ["show_briscola", self._briscola]
+
         for player, card in self._played_cards.items():
             player_id = self._players.index(player)
-            yield ["draw_card", player_id, card]
+            if player == ws_player:
+                yield ["draw_card", player_id, card]
+            else:
+                yield ["draw_card", player_id]
             yield ["play_card", player_id, card]
 
         for player_id, player in enumerate(self._players):
@@ -127,8 +131,6 @@ class Briscola(BaseGame[Player], version=1, number_of_players=2, hand_size=3):
                 return
 
         else:
-            self._current_player_id = (
-                self._current_player_id + 1
-            ) % self.number_of_players
+            self._next_player()
 
         await self._send(self.current_player, "turn")

--- a/carte/static/games/base.css
+++ b/carte/static/games/base.css
@@ -59,7 +59,6 @@
       position: absolute;
       transition-property: top, left, rotate;
       transition-duration: 0.5s;
-
       rotate: calc(var(--card-rotation) * 90deg);
 
       @starting-style {
@@ -98,7 +97,6 @@
           &::before {
             rotate: calc(var(--card-rotation) * (90deg + 90deg * var(--card-rotation)));
             writing-mode: var(--deck-writing-mode);
-
             content: attr(data-deck-count);
             position: absolute;
             inset: 0;
@@ -202,7 +200,7 @@
     border-collapse: collapse;
     line-height: 2.5em;
     tr {
-      &.me {
+      &.self {
         font-weight: bold;
       }
       border-bottom: 1px solid var(--background-secondary-highlight-strong);

--- a/carte/static/games/base.css
+++ b/carte/static/games/base.css
@@ -46,6 +46,8 @@
     --card-bg-x: -1;
     --card-bg-y: -1;
 
+    --card-rotation: 0;
+
     &.card {
       width: var(--card-width);
       height: var(--card-height);
@@ -58,9 +60,12 @@
       transition-property: top, left, rotate;
       transition-duration: 0.5s;
 
+      rotate: calc(var(--card-rotation) * 90deg);
+
       @starting-style {
         top: var(--card-starting-y) !important;
         left: var(--card-starting-x) !important;
+        rotate: calc(var(--card-starting-rotation) * 90deg) !important;
       }
 
       &::after {
@@ -74,24 +79,13 @@
           var(--highlight-high-contrast);
       }
 
-      &[data-back] {
+      &:not([data-suit][data-number]) {
         background-image: var(--card-image-back);
         background-size: 100% 100%;
       }
 
-      &[data-rotated] {
-        --card-rotation-angle: 90deg;
-        rotate: var(--card-rotation-angle);
-        &[data-deck-count]::before {
-          rotate: calc(var(--card-rotation-angle) + 90deg);
-          writing-mode: vertical-rl;
-        }
-        &[data-rotated="back"] {
-          --card-rotation-angle: -90deg;
-        }
-      }
-
       &[data-deck] {
+        --deck-writing-mode: initial;
         &[data-deck-count="0"] {
           visibility: hidden;
         }
@@ -102,6 +96,9 @@
           align-items: center;
           justify-content: center;
           &::before {
+            rotate: calc(var(--card-rotation) * (90deg + 90deg * var(--card-rotation)));
+            writing-mode: var(--deck-writing-mode);
+
             content: attr(data-deck-count);
             position: absolute;
             inset: 0;

--- a/carte/static/games/base.js
+++ b/carte/static/games/base.js
@@ -694,7 +694,7 @@ class BaseGame {
   }
 
   snakeToCamel(str, capitalized = false) {
-    const out = str.replaceAll(/(?:^|_)[a-z]/g, (m) => m.at(-1).toUpperCase());
+    const out = str.replaceAll(/_[a-z]/g, (m) => m.at(-1).toUpperCase());
     if (capitalized) {
       return this.capitalizeFirst(out);
     }

--- a/carte/static/games/base.js
+++ b/carte/static/games/base.js
@@ -678,7 +678,7 @@ class BaseGame {
     );
     for (const [playerId, points] of sortedResults) {
       const row = table.insertRow();
-      if (playerId === this.playerId) {
+      if (this.isPlayerSelf(playerId)) {
         row.classList.add("self");
       }
       const playerCell = row.insertCell();

--- a/carte/static/games/base.js
+++ b/carte/static/games/base.js
@@ -673,7 +673,7 @@ class BaseGame {
 
   cmdResults(...results) {
     const table = document.getElementById("results-table");
-    const sortedResults = Array.from(results.map(Number.parseInt).entries()).sort(
+    const sortedResults = Array.from(results.map((n) => Number.parseInt(n)).entries()).sort(
       ([, a], [, b]) => b - a,
     );
     for (const [playerId, points] of sortedResults) {

--- a/carte/static/games/base.js
+++ b/carte/static/games/base.js
@@ -673,9 +673,9 @@ class BaseGame {
 
   cmdResults(...results) {
     const table = document.getElementById("results-table");
-    const sortedResults = Array.from(results.map((n) => Number.parseInt(n)).entries()).sort(
-      ([, a], [, b]) => b - a,
-    );
+    const sortedResults = Array.from(
+      results.map((n) => Number.parseInt(n)).entries(),
+    ).sort(([, a], [, b]) => b - a);
     for (const [playerId, points] of sortedResults) {
       const row = table.insertRow();
       if (this.isPlayerSelf(playerId)) {

--- a/carte/static/games/briscola.css
+++ b/carte/static/games/briscola.css
@@ -44,7 +44,7 @@
       }
       &[data-starting-position="deck"] {
         --card-starting-x: var(--left);
-        --card-starting-y: calc(var(--center-y));
+        --card-starting-y: calc(var(--center-y) - var(--deck-shadow-width) / 2);
         --card-starting-rotation: 0;
         &[data-position="briscola"] {
           --card-starting-rotation: 1;
@@ -72,7 +72,6 @@
           4
         );
         z-index: var(--card-field-position);
-
         &[data-field-player="opponent"] {
           --card-playing-area-offsets-sign: -1;
         }

--- a/carte/static/games/briscola.css
+++ b/carte/static/games/briscola.css
@@ -37,18 +37,24 @@
       );
     }
 
-    --card-starting-y: var(--center-y);
-    --card-starting-x: var(--left);
-
     &.card {
       &[data-position="deck"] {
         top: calc(var(--center-y) - var(--deck-shadow-width) / 2);
         left: var(--left);
       }
+      &[data-starting-position="deck"] {
+        --card-starting-x: var(--left);
+        --card-starting-y: calc(var(--center-y));
+        --card-starting-rotation: 0;
+        &[data-position="briscola"] {
+          --card-starting-rotation: 1;
+        }
+      }
 
       &[data-position="briscola"] {
         top: var(--center-y);
         left: calc(var(--left) + var(--card-width) / 2);
+        --card-rotation: 1;
         z-index: -1;
       }
 
@@ -65,10 +71,12 @@
           var(--card-width) /
           4
         );
-        &[data-player="opponent"] {
+        z-index: var(--card-field-position);
+
+        &[data-field-player="opponent"] {
           --card-playing-area-offsets-sign: -1;
         }
-        &[data-player="self"] {
+        &[data-field-player="self"] {
           --card-playing-area-offsets-sign: 1;
         }
       }
@@ -76,7 +84,7 @@
       &[data-position="hand"] {
         left: calc(
           var(--center-x) +
-          var(--card-hand-position) *
+          (var(--card-field-position) - (var(--card-field-size) - 1) / 2) *
           (var(--gap) + var(--card-width))
         );
         &[data-player="opponent"] {
@@ -88,6 +96,8 @@
       }
 
       &[data-position="points"] {
+        --card-rotation: 1;
+        --deck-writing-mode: vertical-rl;
         left: calc(var(--left) + var(--rotation-diff));
         &[data-player="opponent"] {
           top: calc(var(--top) - var(--rotation-diff));

--- a/carte/static/games/briscola.js
+++ b/carte/static/games/briscola.js
@@ -81,7 +81,7 @@ class Briscola extends BaseGame {
     const player = this.getPlayerIdentifier(playerId);
 
     const params = new Map();
-    if (this.playerId !== Number.parseInt(playerId)) {
+    if (!this.isPlayerSelf(playerId)) {
       params.set("suit", null);
       params.set("number", null);
     }


### PR DESCRIPTION
 - added a CardGroup class to handle movement between CardField(s) and Deck(s)
 - reworked the transition awaiting scheme, to accomodate for the new behaviour
 - introduced a "data-starting-position" datatag to accomodate for cards having different starting positions and behaviour (i.e. cards being drawn from different decks)
 - removed the "data-back" (substituted by the absence of "data-suit" and "data-number") and "data-rotated" datatags (substituted by a general rotate property controlled by a "--card-rotation" variable)
 - some more minor improvements